### PR TITLE
Convert intent extras to JSON so that they can be access from the application.

### DIFF
--- a/src/android/IntentPlugin.java
+++ b/src/android/IntentPlugin.java
@@ -164,7 +164,7 @@ public class IntentPlugin extends CordovaPlugin {
             }
 
             intentJSON.put("type", intent.getType());
-            intentJSON.put("extras", intent.getExtras());
+            intentJSON.put("extras", toJsonObject(intent.getExtras()));
             intentJSON.put("action", intent.getAction());
             intentJSON.put("categories", intent.getCategories());
             intentJSON.put("flags", intent.getFlags());
@@ -182,4 +182,40 @@ public class IntentPlugin extends CordovaPlugin {
         }
     }
 
+    private static JSONObject toJsonObject(Bundle bundle) {
+      try {
+        return (JSONObject) toJsonValue(bundle);
+      } catch (JSONException e) {
+        throw new IllegalArgumentException("Cannot convert bundle to JSON: " + e.getMessage(), e);
+      }
+    }
+  
+    private static Object toJsonValue(final Object value) throws JSONException {
+      if (value == null) {
+        return null;
+      } else if (value instanceof Bundle) {
+        final Bundle bundle = (Bundle) value;
+        final JSONObject result = new JSONObject();
+        for (final String key : bundle.keySet()) {
+          result.put(key, toJsonValue(bundle.get(key)));
+        }
+        return result;
+      } else if (value.getClass().isArray()) {
+        final JSONArray result = new JSONArray();
+        int length = Array.getLength(value);
+        for (int i = 0; i < length; ++i) {
+          result.put(i, toJsonValue(Array.get(value, i)));
+        }
+        return result;
+      } else if (
+          value instanceof String
+              || value instanceof Boolean
+              || value instanceof Integer
+              || value instanceof Long
+              || value instanceof Double) {
+        return value;
+      } else {
+        return String.valueOf(value);
+      }
+  }
 }

--- a/src/android/IntentPlugin.java
+++ b/src/android/IntentPlugin.java
@@ -1,5 +1,6 @@
 package com.napolitano.cordova.plugin.intent;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Set;
@@ -11,6 +12,7 @@ import org.json.JSONObject;
 import android.content.ClipData;
 import android.content.Intent;
 import android.os.Build;
+import android.os.Bundle;
 import android.util.Log;
 
 import android.content.ContentResolver;


### PR DESCRIPTION
Previously, if you looked at the extras from within the application you would just see the result of the Bundle.toString invocation, which was not very helpful. This change exposes the content of the bundle to the application as a JSON object.
