### PR TITLE
minor addition to readme regarding launchmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Setting the launch mode to "singleTask" ensures that your app cannot run in mult
 </activity>
 ```
 
+Cordova >= 6.0.0 apparently requires the launchMode to be set in ``config.xml`` as well:
+```xml
+<platform name="android">
+    ...
+    <preference name="AndroidLaunchMode" value="singleTask"/>
+</platform>
+```
+
 ## Installation
 
 Add the plugin to your project using Cordova CLI:


### PR DESCRIPTION
This fixed the issue that launchMode from AndroidManifest.xml was not respected for me. Other suggestions from stackoverflow had no impact/effect. This is taken from the official documentation at https://cordova.apache.org/docs/en/latest/guide/platforms/android/config.html
